### PR TITLE
Add new model name for Aqara wireless mini switch

### DIFF
--- a/drivers/button_switch.aq2/driver.js
+++ b/drivers/button_switch.aq2/driver.js
@@ -1,5 +1,5 @@
 const Homey = require("homey");
-const model = ["sensor_switch.aq2", "sensor_switch"];
+const model = ["sensor_switch.aq2", "sensor_switch", "remote.b1acn01"];
 
 class AqaraButtonSwitch extends Homey.Driver {
   onInit() {


### PR DESCRIPTION
Hi Maxmudjon,

First of all many thanks for your great homey app, I've been using it with pleasure for some time now!
Recently though I wanted to add some Aqara Smart Wireless Switches that were successfully linked to the Xiaomi gateway, but I was unable to pair in the mihomey app.
(https://nl.aliexpress.com/item/32950471459.html?spm=a2g0s.9042311.0.0.398d4c4dahEsfK)
After some debugging I found that the model-name for this switch apparently sometimes also is 'lumi.remote.b1acn01.'
With this patch adding and using the button works like a charm!